### PR TITLE
Allow play button to un-pause the player

### DIFF
--- a/src/vueaudio.plugin.js
+++ b/src/vueaudio.plugin.js
@@ -92,7 +92,7 @@ export default {
       this.audio.currentTime = 0
     },
     play: function () {
-      if (this.playing) return
+      if (this.playing && !this.paused) return
       this.paused = false
       this.audio.play()
       this.playing = true


### PR DESCRIPTION
The expected behavior for media players is that the play button can be used to resume playing from a `paused` state, in addition to toggling the pause button a second time.

This allows for the play button to un-pause the media.